### PR TITLE
fix Patient address state handling

### DIFF
--- a/src/main/java/edu/gatech/chai/omoponfhir/omopv5/r4/mapping/OmopPatient.java
+++ b/src/main/java/edu/gatech/chai/omoponfhir/omopv5/r4/mapping/OmopPatient.java
@@ -1025,7 +1025,7 @@ public class OmopPatient extends BaseOmopResource<USCorePatient, FPerson, FPerso
 			Address address = addresses.get(0);
 			// We should check the state.
 			String state = address.getState();
-			if (state.length() != 2) {
+			if (state != null && state.length() != 2) {
 				String twoState = twoLetterStateMap.getTwoLetter(state);
 				if (twoState == null || twoState.isEmpty()) {
 					if (state.length() < 2) {


### PR DESCRIPTION
When testing with data, I found that in case the state is not given in the FHIR  Patient resource, the code errors out.

The returned response was as stated up top in the log.
This is the log I got from the server which helped me in finding the code.


```
ca.uhn.fhir.rest.server.exceptions.InternalErrorException: HAPI-0389: Failed to call access method: java.lang.NullPointerException: Cannot invoke "String.length()" because "state" is null
        at ca.uhn.fhir.rest.server.method.BaseMethodBinding.invokeServerMethod(BaseMethodBinding.java:272)
        at ca.uhn.fhir.rest.server.method.BaseOutcomeReturningMethodBinding.invokeServer(BaseOutcomeReturningMethodBinding.java:174)
        at ca.uhn.fhir.rest.server.method.UpdateMethodBinding.invokeServer(UpdateMethodBinding.java:42)
        at ca.uhn.fhir.rest.server.RestfulServer.handleRequest(RestfulServer.java:1201)
        at ca.uhn.fhir.rest.server.RestfulServer.doPut(RestfulServer.java:442)
        at ca.uhn.fhir.rest.server.RestfulServer.service(RestfulServer.java:1964)
        at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:710)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:130)
        at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:109)
        at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:167)
        at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:79)
        at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:483)
        at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:116)
        at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93)
        at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:666)
        at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74)
        at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343)
        at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:396)
        at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63)
        at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:903)
        at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1744)
        at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52)
        at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
        at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:59)
        at java.base/java.lang.Thread.run(Unknown Source)
Caused by: java.lang.reflect.InvocationTargetException: null
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
        at java.base/java.lang.reflect.Method.invoke(Unknown Source)
        at ca.uhn.fhir.rest.server.method.BaseMethodBinding.invokeServerMethod(BaseMethodBinding.java:264)
        ... 26 common frames omitted
Caused by: java.lang.NullPointerException: Cannot invoke "String.length()" because "state" is null
        at edu.gatech.chai.omoponfhir.omopv5.r4.mapping.OmopPatient.constructOmop(OmopPatient.java:1028)
        at edu.gatech.chai.omoponfhir.omopv5.r4.mapping.OmopPatient.toDbase(OmopPatient.java:503)
        at edu.gatech.chai.omoponfhir.r4.provider.PatientResourceProvider.updatePatient(PatientResourceProvider.java:361)
        ... 29 common frames omitted
```